### PR TITLE
ide/epj2make: makefile generation: print a single file per line for all file lists in order to be diff friendly.

### DIFF
--- a/ide/src/project/Project.ec
+++ b/ide/src/project/Project.ec
@@ -411,7 +411,7 @@ int OutputFileList(File f, char * name, Array<String> list, Map<String, int> var
 {
    int numOfBreaks = 0;
    const int breakListLength = 1536;
-   const int breakLineLength = 78;
+   const int breakLineLength = 78; // TODO: turn this into an option.
 
    int c, len, itemCount = 0;
    Array<int> breaks { };
@@ -467,17 +467,22 @@ int OutputFileList(File f, char * name, Array<String> list, Map<String, int> var
          itemCount = breaks[c];
          for(n=offset; n<offset+itemCount; n++)
          {
-            int itemLen = strlen(list[n]);
-            if(len > 3 && len + itemLen > breakLineLength)
+            if(false) // TODO: turn this into an option.
             {
-               f.Printf(" \\\n\t%s", list[n]);
-               len = 3;
+               int itemLen = strlen(list[n]);
+               if(len > 3 && len + itemLen > breakLineLength)
+               {
+                  f.Printf(" \\\n\t%s", list[n]);
+                  len = 3;
+               }
+               else
+               {
+                  len += itemLen;
+                  f.Printf(" %s", list[n]);
+               }
             }
             else
-            {
-               len += itemLen;
-               f.Printf(" %s", list[n]);
-            }
+               f.Printf(" \\\n\t%s", list[n]);
          }
          offset += itemCount;
          f.Printf("\n");


### PR DESCRIPTION
is this something you're not ready to pull because of the new users of the build system at work?
