### PR TITLE
ide; added secret ctrl+shift hotkey for disabling parsing of source code...

### DIFF
--- a/ide/src/debugger/Debugger.ec
+++ b/ide/src/debugger/Debugger.ec
@@ -687,7 +687,7 @@ class Debugger
       codloc = CodeLocation::ParseCodeLocation(location);
       if(codloc)
       {
-         CodeEditor editor = (CodeEditor)ide.OpenFile(codloc.absoluteFile, normal, true, null, no, normal);
+         CodeEditor editor = (CodeEditor)ide.OpenFile(codloc.absoluteFile, normal, true, null, no, normal, false);
          if(editor)
          {
             EditBox editBox = editor.editBox;
@@ -732,7 +732,7 @@ class Debugger
                }
             }
             if(frame.absoluteFile)
-               editor = (CodeEditor)ide.OpenFile(frame.absoluteFile, normal, true, null, no, normal);
+               editor = (CodeEditor)ide.OpenFile(frame.absoluteFile, normal, true, null, no, normal, false);
             ide.Update(null);
             if(editor && frame.line)
             {
@@ -2082,14 +2082,14 @@ class Debugger
       
       strcpy(path, ide.workspace.projectDir);
       PathCat(path, tempPath);
-      codeEditor = (CodeEditor)ide.OpenFile(path, Normal, false, null, no);
+      codeEditor = (CodeEditor)ide.OpenFile(path, Normal, false, null, no, normal, false);
       if(!codeEditor)
       {
          for(srcDir : ide.workspace.sourceDirs)
          {
             strcpy(path, srcDir);
             PathCat(path, tempPath);
-            codeEditor = (CodeEditor)ide.OpenFile(path, Normal, false, null, no);
+            codeEditor = (CodeEditor)ide.OpenFile(path, Normal, false, null, no, normal, false);
             if(codeEditor) break;
          }
       }
@@ -2100,7 +2100,7 @@ class Debugger
       if(!activeFrame || !activeFrame.absoluteFile)
          codeEditor = null;
       else
-         codeEditor = (CodeEditor)ide.OpenFile(activeFrame.absoluteFile, normal, false, null, no, normal);
+         codeEditor = (CodeEditor)ide.OpenFile(activeFrame.absoluteFile, normal, false, null, no, normal, false);
       if(codeEditor)
       {
          codeEditor.inUseDebug = true;

--- a/ide/src/designer/CodeEditor.ec
+++ b/ide/src/designer/CodeEditor.ec
@@ -683,6 +683,8 @@ class CodeEditor : Window
 
    Designer designer { codeEditor = this, visible = false, saveDialog = codeEditorFormFileDialog };
 
+   bool noParsing;
+
    void ProcessCaretMove(EditBox editBox, int line, int charPos)
    {
       char temp[512];
@@ -2360,7 +2362,7 @@ class CodeEditor : Window
       if(fileName)
       {
          GetExtension(fileName, ext);
-         if(!strcmpi(ext, "ec"))
+         if(!noParsing && !(noParsing = ide.noParsing) && !strcmpi(ext, "ec"))
          {
             codeModified = true;
             EnsureUpToDate();
@@ -4396,6 +4398,7 @@ class CodeEditor : Window
    void UpdateFormCode()
    {
       if(!this) return;
+      if(noParsing) return;
          
       updatingCode++;
       if(codeModified)

--- a/ide/src/dialogs/NodeProperties.ec
+++ b/ide/src/dialogs/NodeProperties.ec
@@ -171,10 +171,10 @@ class NodeProperties : Window
 
    bool OnKeyDown(Key key, unichar ch)
    {
-      if(key == escape || (SmartKey)key == enter)
+      if(key == escape || key.code == enter || key.code == keyPadEnter)
       {
          StopEditing();
-         if((SmartKey)key == enter)
+         if(key.code == enter || key.code == keyPadEnter)
          {
             if(mode == newFile)
             {
@@ -182,7 +182,7 @@ class NodeProperties : Window
                Window document;
                node.GetFullFilePath(filePath);
                if(FileExists(filePath))
-                  ide.projectView.OpenNode(node);
+                  ide.projectView.OpenNode(node, key.ctrl && key.shift);
                else
                {
                   document = (Window)NewCodeEditor(ide, normal, false);

--- a/ide/src/panels/OutputView.ec
+++ b/ide/src/panels/OutputView.ec
@@ -21,7 +21,7 @@ class OutputView : Window
    size.h = 240;
    background = formColor;
 
-   virtual void OnGotoError(char * line);
+   virtual void OnGotoError(char * line, bool noParsing);
    virtual void OnCodeLocationParseAndGoTo(char * line);
 
    FindDialog findDialog { master = this, editBox = buildBox, isModal = true, autoCreate = false, text = "Find" };
@@ -128,15 +128,15 @@ class OutputView : Window
       
       bool NotifyDoubleClick(EditBox editBox, EditLine line, Modifiers mods)
       {
-         OnGotoError(editBox.line.text);
+         OnGotoError(editBox.line.text, mods.ctrl && mods.shift);
          return false; //true; // why not use true here? 
       }
 
       bool NotifyKeyDown(EditBox editBox, Key key, unichar ch)
       {
-         if((SmartKey)key == enter)
+         if(key.code == enter || key.code == keyPadEnter)
          {
-            OnGotoError(editBox.line.text);
+            OnGotoError(editBox.line.text, key.ctrl && key.shift);
             return false;
          }
          return true;


### PR DESCRIPTION
... when opening files in the ide.

holding ctrl+shift down when clicking a recent menu item or when opening files from the project view and output view.
also added -no-parsing command line switch.

Conflicts:
    ide/src/ide.ec
