### PR TITLE
ide: use ctrl only for noParsing and ctrl+shift for openAsText when o…

### DIFF
--- a/ide/src/ide.ec
+++ b/ide/src/ide.ec
@@ -598,23 +598,23 @@ class IDEWorkSpace : Window
    {
       parent = this;
 
-      void OnGotoError(const char * line, bool noParsing)
+      void OnGotoError(const char * line, bool openAsText, bool noParsing)
       {
          CompilerConfig compiler = ide.workspace ? ideConfig.compilers.GetCompilerConfig(ide.workspace.activeCompiler) : null;
          const char * objectFileExt = compiler ? compiler.objectFileExt : objectDefaultFileExt;
-         ide.GoToError(line, noParsing, objectFileExt);
+         ide.GoToError(line, openAsText, noParsing, objectFileExt);
          delete compiler;
       }
 
-      void OnCodeLocationParseAndGoTo(const char * line)
+      void OnCodeLocationParseAndGoTo(const char * line, bool openAsText, bool noParsing)
       {
          CompilerConfig compiler = ide.workspace ? ideConfig.compilers.GetCompilerConfig(ide.workspace.activeCompiler) : null;
          const char * objectFileExt = compiler ? compiler.objectFileExt : objectDefaultFileExt;
          bool inFind = ide.outputView.activeBox == ide.outputView.findBox;
          if(inFind)
-            ide.CodeLocationParseAndGoTo(line, ide.findInFilesDialog.findProject, ide.findInFilesDialog.findDir, objectFileExt);
+            ide.CodeLocationParseAndGoTo(line, ide.findInFilesDialog.findProject, ide.findInFilesDialog.findDir, openAsText, noParsing, objectFileExt);
          else
-            ide.CodeLocationParseAndGoTo(line, null, null, objectFileExt);
+            ide.CodeLocationParseAndGoTo(line, null, null, openAsText, noParsing, objectFileExt);
          delete compiler;
       }
 
@@ -927,7 +927,7 @@ class IDEWorkSpace : Window
                bool isProjectFile;
                char extension[MAX_EXTENSION] = "";
                GetExtension(file, extension);
-               isProjectFile = (!strcmpi(extension, "epj") || !strcmpi(extension, "ews"));
+               isProjectFile = (!strcmpi(extension, ProjectExtension) || !strcmpi(extension, WorkspaceExtension));
                if(mods.ctrl && !mods.shift)
                {
                   char * command = PrintString("ecere-ide ", isProjectFile ? "-t " : "", file);
@@ -2852,10 +2852,10 @@ class IDEWorkSpace : Window
       return true;
    }
 
-   void GoToError(const char * line, bool noParsing, const char * objectFileExt)
+   void GoToError(const char * line, bool openAsText, bool noParsing, const char * objectFileExt)
    {
       if(projectView)
-         projectView.GoToError(line, noParsing, objectFileExt);
+         projectView.GoToError(line, openAsText, noParsing, objectFileExt);
    }
 
    FileAttribs GoToCodeSelectFile(const char * filePath, const char * dir, Project prj, ProjectNode * node, char * selectedPath, const char * objectFileExt)
@@ -2948,7 +2948,7 @@ class IDEWorkSpace : Window
       return result;
    }
 
-   void CodeLocationParseAndGoTo(const char * text, Project project, const char * dir, const char * objectFileExt)
+   void CodeLocationParseAndGoTo(const char * text, Project project, const char * dir, bool openAsText, bool noParsing, const char * objectFileExt)
    {
       char *s = null;
       const char *path = text;
@@ -3056,10 +3056,10 @@ class IDEWorkSpace : Window
       }
 
       if((fileAttribs = GoToCodeSelectFile(filePath, dir, prj, null, completePath, objectFileExt)))
-         CodeLocationGoTo(completePath, fileAttribs, line, col);
+         CodeLocationGoTo(completePath, fileAttribs, line, col, openAsText, noParsing);
    }
 
-   void CodeLocationGoTo(const char * path, const FileAttribs fileAttribs, int line, int col)
+   void CodeLocationGoTo(const char * path, const FileAttribs fileAttribs, int line, int col, bool openAsText, bool noParsing)
    {
       if(fileAttribs.isFile)
       {
@@ -3077,7 +3077,8 @@ class IDEWorkSpace : Window
          }
          else
          {
-            CodeEditor codeEditor = (CodeEditor)OpenFile(path, false, true, !strcmpi(ext, "epj") ? "txt" : ext, no, normal, false);
+            bool asText = (openAsText || !strcmpi(ext, ProjectExtension) || !strcmpi(ext, WorkspaceExtension));
+            CodeEditor codeEditor = (CodeEditor)OpenFile(path, false, true, asText ? "txt" : ext, no, normal, noParsing);
             if(codeEditor && codeEditor._class == class(CodeEditor) && line)
             {
                EditBox editBox = codeEditor.editBox;
@@ -3385,7 +3386,7 @@ class IDEWorkSpace : Window
             PathCat(fullPath, app.argv[c]);
             StripLastDirectory(fullPath, parentPath);
             GetExtension(app.argv[c], ext);
-            isProject = !openAsText && !strcmpi(ext, "epj");
+            isProject = !openAsText && !strcmpi(ext, ProjectExtension);
 
             if(isProject && c > 1 + (ide.debugStart ? 1 : 0)) continue;
 

--- a/ide/src/panels/OutputView.ec
+++ b/ide/src/panels/OutputView.ec
@@ -59,8 +59,8 @@ class OutputView : Window
    size.h = 240;
    background = formColor;
 
-   virtual void OnGotoError(const char * line, bool noParsing);
-   virtual void OnCodeLocationParseAndGoTo(const char * line);
+   virtual void OnGotoError(const char * line, bool openAsText, bool noParsing);
+   virtual void OnCodeLocationParseAndGoTo(const char * line, bool openAsText, bool noParsing);
 
    FindDialog findDialog { master = this, editBox = buildBox, isModal = true, autoCreate = false, text = $"Find" };
 
@@ -176,7 +176,7 @@ class OutputView : Window
 
       bool NotifyDoubleClick(EditBox editBox, EditLine line, Modifiers mods)
       {
-         OnGotoError(editBox.line.text, mods.ctrl && mods.shift);
+         OnGotoError(editBox.line.text, mods.ctrl && mods.shift, mods.ctrl && !mods.shift);
          return false;
       }
 
@@ -237,7 +237,7 @@ class OutputView : Window
                   buildBox.GoToLineNum(marks[nextPos].lineNumber - 1);
                   if(outputView.autoGo.checked)
                   {
-                     outputView.OnGotoError(this.line.text, false);
+                     outputView.OnGotoError(this.line.text, false, false);
                      Activate();
                   }
                }
@@ -251,7 +251,7 @@ class OutputView : Window
       {
          if(key.code == enter || key.code == keyPadEnter)
          {
-            OnGotoError(editBox.line.text, key.ctrl && key.shift);
+            OnGotoError(editBox.line.text, key.ctrl && key.shift, key.ctrl && !key.shift);
             return false;
          }
          return true;
@@ -281,15 +281,15 @@ class OutputView : Window
 
       bool NotifyDoubleClick(EditBox editBox, EditLine line, Modifiers mods)
       {
-         OnCodeLocationParseAndGoTo(editBox.line.text);
+         OnCodeLocationParseAndGoTo(editBox.line.text, mods.ctrl && mods.shift, mods.ctrl && !mods.shift);
          return false;
       }
 
       bool NotifyKeyDown(EditBox editBox, Key key, unichar ch)
       {
-         if((SmartKey)key == enter)
+         if(key.code == enter || key.code == keyPadEnter)
          {
-            OnCodeLocationParseAndGoTo(editBox.line.text);
+            OnCodeLocationParseAndGoTo(editBox.line.text, key.ctrl && key.shift, key.ctrl && !key.shift);
             return false;
          }
          return true;
@@ -311,15 +311,15 @@ class OutputView : Window
 
       bool NotifyDoubleClick(EditBox editBox, EditLine line, Modifiers mods)
       {
-         OnCodeLocationParseAndGoTo(editBox.line.text);
+         OnCodeLocationParseAndGoTo(editBox.line.text, mods.ctrl && mods.shift, mods.ctrl && !mods.shift);
          return false;
       }
 
       bool NotifyKeyDown(EditBox editBox, Key key, unichar ch)
       {
-         if((SmartKey)key == enter)
+         if(key.code == enter || key.code == keyPadEnter)
          {
-            OnCodeLocationParseAndGoTo(editBox.line.text);
+            OnCodeLocationParseAndGoTo(editBox.line.text, key.ctrl && key.shift, key.ctrl && !key.shift);
             return false;
          }
          return true;

--- a/ide/src/project/ProjectView.ec
+++ b/ide/src/project/ProjectView.ec
@@ -1693,7 +1693,7 @@ class ProjectView : Window
       return result;
    }
 
-   void GoToError(const char * line, const bool noParsing, const char * objectFileExt)
+   void GoToError(const char * line, bool openAsText, bool noParsing, const char * objectFileExt)
    {
       char * colon;
 
@@ -1883,7 +1883,7 @@ class ProjectView : Window
 
                if(ide.GoToCodeSelectFile(moduleName, null, project, null, filePath, objectFileExt))
                {
-                  codeEditor = (CodeEditor)ide.OpenFile(filePath, false, true, null, no, normal, noParsing);
+                  codeEditor = (CodeEditor)ide.OpenFile(filePath, false, true, openAsText ? "txt" : null, no, normal, noParsing);
                   ide.RepositionWindows(false);
                }
 
@@ -1895,12 +1895,12 @@ class ProjectView : Window
                      PathCatSlash(filePath, moduleName);
                   }
 
-                  codeEditor = (CodeEditor)ide.OpenFile(filePath, false, true, null, no, normal, noParsing);
+                  codeEditor = (CodeEditor)ide.OpenFile(filePath, false, true, openAsText ? "txt" : null, no, normal, noParsing);
                   if(!codeEditor && !strcmp(ext, "c"))
                   {
                      char ecName[MAX_LOCATION];
                      ChangeExtension(filePath, "ec", ecName);
-                     codeEditor = (CodeEditor)ide.OpenFile(ecName, false, true, null, no, normal, noParsing);
+                     codeEditor = (CodeEditor)ide.OpenFile(ecName, false, true, openAsText ? "txt" : null, no, normal, noParsing);
                   }
                   if(!codeEditor)
                   {


### PR DESCRIPTION
…pening a file from output view logs and automatically open as text for workspace files like project files.