### PR TITLE
epj2make, ide: makefile generation: use CXX instead of CC for linking…

### DIFF
--- a/ide/src/project/Project.ec
+++ b/ide/src/project/Project.ec
@@ -3626,7 +3626,7 @@ private:
 
          f.Puts("ifndef STATIC_LIBRARY_TARGET\n");
 
-         f.Puts("\t$(LD) $(OFLAGS) @$(OBJ)objects.lst $(LIBS) -o $(TARGET) $(INSTALLNAME)\n");
+         f.Printf("\t$(%s) $(OFLAGS) @$(OBJ)objects.lst $(LIBS) -o $(TARGET) $(INSTALLNAME) $(SONAME)\n", containsCXX ? "CXX" : "CC");
          if(!GetDebug(config))
          {
             f.Puts("ifndef NOSTRIP\n");


### PR DESCRIPTION
… when project contains C++ files.