### PR TITLE
ecere/com/String (ZString): fix uninitialized empty string when calli…

### DIFF
--- a/ecere/src/com/String.ec
+++ b/ecere/src/com/String.ec
@@ -1411,8 +1411,8 @@ public:
          {
             memcpy(_string + len, s._string, addedLen);
             len += addedLen;
-            _string[len] = 0;
          }
+         _string[len] = 0;
          // WARNING: auto-decref'ing for now when s is of pointer type!
          if(s.allocType == pointer)
             delete s;


### PR DESCRIPTION
…ng ZString::concatn to concatenate an empty string to a null string. earlier concat fix: adfe8c0ee5055471c22e89cb0cb80c5bfe3ac814