### PR TITLE
Struct that allows field values to be a numeric type, a string, an array or an object. 

### DIFF
--- a/ecere/src/sys/JSON.ec
+++ b/ecere/src/sys/JSON.ec
@@ -225,12 +225,13 @@ private:
       {
          if(type.type == structClass)
          {
-            customValuefication = ch != '{' || strstr(type.name, "ProcessInputValue");
+            customValuefication = ch != '{' || strstr(type.name, "FlexyField") || strstr(type.name, "ProcessInputValue");
             specialValuefication = customValuefication && (
-               strstr(type.name, "FieldValue") ||
-               strstr(type.name, "GeoJSONValue") ||
-               strstr(type.name, "MBGLFilterValue") ||
-               strstr(type.name, "ProcessInputValue") );
+                  strstr(type.name, "FieldValue") ||
+                  strstr(type.name, "FlexyField") ||
+                  strstr(type.name, "GeoJSONValue") ||
+                  strstr(type.name, "MBGLFilterValue") ||
+                  strstr(type.name, "ProcessInputValue") );
          }
          else if(type.type == normalClass && ch !='{')
          {

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -116,8 +116,6 @@ public struct FieldValue
 
    void OnCopy(FieldValue b)
    {
-      // Free any allocated memory first.
-      this.OnFree();
       this = b;
       if(type.type == text && type.mustFree)
          s = CopyString(b.s);
@@ -286,8 +284,6 @@ public:
    //       delete a; // deallocates an_array, but b.m["key"] still points at it.
    //       delete b; // attempts to call OnFree() with the deleted b.m["key"].
    //
-   // Since "OnCopy" calls "OnDelete", it requires attention too, in a set-up like this.
-   //
    // The values of type can be altered after assignment if necessary (eg: set
    //   type = {nil, false}, since there is no property for nil values, or  set
    //   mustFree to false for a string that we know is referenced elsewhere):
@@ -404,8 +400,6 @@ public:
 
    void OnCopy(FlexyField other)
    {
-      // Free any allocated memory first.
-      this.OnFree();
       this = other;
       if(type.mustFree)
       {

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -593,4 +593,37 @@ public:
       }
       return tempString;
    }
+
+   String stringify()
+   {
+      // Return a string representation of the value:
+      // A new String is allocated and must be deleted by the caller.
+      // The resulting string may not be suitable for json/econ files.
+
+      char temp[MAX_LOCATION];
+      switch(type.type)
+      {
+         case integer:
+            formatInteger(temp, i, type.format, type.isUnsigned);
+            return CopyString(temp);
+         case real:
+            formatFloat(temp, r, type.format, false);
+            return CopyString(temp);
+         case text:
+            return CopyString(s);
+         case blob:
+            // At the moment, we assume that all blobs
+            // are actually text that must be stored verbatim,
+            // we do not treat binary data here.
+            return CopyString((String)b);
+         case array:
+         case map:
+            {
+               ObjectNotationType on = econ;
+               this.OnGetString(temp, null, &on);
+               return CopyString(temp);
+            }
+      }
+      return null;
+   }
 };

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -437,4 +437,68 @@ public:
          }
       }
    }
+
+   void OnSerialize(IOChannel f)
+   {
+      f.Put(type);
+      switch(type.type)
+      {
+         case integer:
+            f.Put(i); break;
+         case real:
+            f.Put(r); break;
+         case text:
+            f.Put(s); break;
+         case blob:
+            // At the moment, we assume that all blobs
+            // are actually text that must be stored verbatim,
+            // we do not treat binary data here.
+            f.Put((String)b); break;
+         case array:
+            a.OnSerialize(f); break;
+         case map:
+            m.OnSerialize(f); break;
+      }
+   }
+
+   void OnUnserialize(IOChannel f)
+   {
+      // First free any allocated space.
+      this.OnFree();
+      f.Get(type);
+      switch(type.type)
+      {
+         case integer:
+            f.Get(i);
+            break;
+         case real:
+            f.Get(r);
+            break;
+         case text:
+            f.Get(s);
+         case blob:
+            // At the moment, we assume that all blobs
+            // are actually text that must be stored verbatim,
+            // we do not treat binary data here.
+            f.Get(s);
+            break;
+         case array:
+            {
+               Array<FlexyField> at {};
+               at.OnUnserialize(f);
+               a = at;
+               break;
+            }
+         case map:
+            {
+               Map<String, FlexyField> mt {};
+               mt.OnUnserialize(f);
+               m = mt;
+               break;
+            }
+         default:
+            r = 0;
+            break;
+      }
+   }
 };

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -227,3 +227,20 @@ public struct FieldValue
       return false;
    }
 };
+
+// Add array and map to the enumeration of known field types.
+// Note that the new values are not compatible with SQLiteType objects.
+public enum FlexyType : FieldType {
+   array, // The blob points to an Array<FlexyField> object
+   map    // the blob points to a Map<String, FlexyField> object
+};
+
+
+public class FlexyTypeEx : FlexyType
+{
+public:
+   FlexyType type:3;
+   bool mustFree:1;
+   FieldValueFormat format:3;
+   bool isUnsigned:1;
+};

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -327,4 +327,41 @@ public:
        set{ m = value; type = {map, true};}
       isset { return type.type == map && m != null;}
    }
+
+   int OnCompare(FlexyField other)
+   {
+      // Return -1, 0, 1 if this is respectively smaller equal or larger than other.
+
+      if(type.type < other.type.type) return -1;
+      if(type.type > other.type.type) return  1;
+      switch(type.type)
+      {
+         case integer:
+            return ((i > other.i) - (i < other.i));
+         case real:
+            return ((r > other.r) - (r < other.r));
+         case text:
+            return compareText(other);
+         case blob:
+            // At the moment, we assume that all blobs
+            // are actually text that must be stored verbatim,
+            // we do not treat bynary data here.
+            return compareText(other);
+         case array:
+         case map:
+         default:
+            // We consider arrays and maps to compare equal
+            // until a sensible ordering is devised.
+            return 0;
+      }
+      return 0;
+   }
+
+   int compareText(FlexyField other)
+   {
+      if(!s && other.s) return -1;
+      if(s && !other.s) return 1;
+      if(!s && !other.s) return 0;
+      return strcmp(s, other.s);
+   }
 };

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -389,4 +389,52 @@ public:
          }
       }
    }
+
+   void OnCopy(FlexyField other)
+   {
+      // Free any allocated memory first.
+      this.OnFree();
+      this = other;
+      if(type.mustFree)
+      {
+         switch (type.type)
+         {
+            case text:
+               s = CopyString(other.s);
+               break;
+            case blob:
+               // At the moment, we assume that all raw  blobs
+               // are actually text that must be stored verbatim,
+               // we do not treat binary data here.
+               s = CopyString((String)other.b);
+               break;
+            case array :
+               {
+                  Array<FlexyField> at {};
+                  int n;
+                  for ( n=0; n< a.count; n++ )
+                  {
+                     at.Add({});
+                     at[n].OnCopy(a[n]);
+                  }
+                  a = at;
+                  break;
+               }
+            case map:
+               {
+                  Map<String, FlexyField> mt {};
+                  MapIterator<String, FlexyField> iter {map = other.m};
+                  for (iter.Next(); iter.pointer; iter.Next())
+                  {
+                     const String key = iter.key;
+                     FlexyField val = iter.value;
+                     mt[key] = {};
+                     mt[key].OnCopy(val);
+                  }
+                  m = mt;
+                  break;
+               }
+         }
+      }
+   }
 };

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -126,6 +126,8 @@ public struct FieldValue
 
    void OnCopy(FieldValue b)
    {
+      // Free any allocated memory first.
+      this.OnFree();
       this = b;
       if(type.type == text && type.mustFree)
          s = CopyString(b.s);

--- a/eda/libeda/src/fieldValue.ec
+++ b/eda/libeda/src/fieldValue.ec
@@ -364,4 +364,29 @@ public:
       if(!s && !other.s) return 0;
       return strcmp(s, other.s);
    }
+
+   void OnFree()
+   {
+      if(type.mustFree)
+      {
+         if(type.type == text && s)
+         {
+            delete s;
+         }
+         else if(type.type == blob)
+         {
+            delete b;
+         }
+         else if (type.type == array && a)
+         {
+            a.OnFree();
+            a = null;
+         }
+         else if (type.type == map && m)
+         {
+            m.OnFree();
+            m = null;
+         }
+      }
+   }
 };


### PR DESCRIPTION
FlexyField is a generalization of FieldValue that can additionally hold references to Array<FlexyField> (property 'a') or Map<String, FlexyField> (property 'm').
To avoid changing the behavior of FieldValue and avoid a complex implementation, FlexyField is not derived from FieldValue, although they share the same basic structure.

Setting a value in a FlexyField object automaticaly sets the flags, assuming that array, map, text and blob types need mustFree=true, which seems the more frequent case: if that is not the case that flag has to be set manually.

The OnGetDataFromString method parses strings starting with '[' into  values for property 'a' and strings starting with '{' into values for property 'm'.
Other cases are treated the same way as in FieldValue and whatever does not fit anything else, is stored as a blob.