### PR TITLE
JSON.ec: PrintObjectNotationString: add null terminator to avoid edge…

### DIFF
--- a/ecere/src/sys/JSON.ec
+++ b/ecere/src/sys/JSON.ec
@@ -2934,6 +2934,7 @@ public String PrintObjectNotationString(Class objectType, void * object, ObjectN
       TempFile f { };
       if(WriteONObject(f, objectType, object, 0, onType == econ, null, false, 0, null))
       {
+         f.Putc('\0');
          if(indent>0)
            result =  StringIndent((String)f.buffer, indent * jsonIndentWidth, indentFirst);
          else


### PR DESCRIPTION

    If the TempFile buffer auto-resizes to the exact length of the string
    that is being written in it, the null terminator is lost.

    Rather than changing the behavior of TempFile, adding an extra '\0' to
    the buffer via Putc works around the issue.