### PR TITLE
eccss->expressions: fixed a bug causing bitNot cmss expressions to pr…

### DIFF
--- a/compiler/eccss/expressions.ec
+++ b/compiler/eccss/expressions.ec
@@ -749,7 +749,7 @@ public:
    {
       if(exp1) { exp1.print(out, indent, o); if(exp2) out.Print(" "); }
       op.print(out, indent, o);
-      if(exp2) { if(exp1) out.Print(" "); exp2.print(out, indent, o); }
+      if(exp2) { if(exp1 || op == bitNot) out.Print(" "); exp2.print(out, indent, o); }
    }
 
    CMSSExpression ::parse(int prec, CMSSLexer lexer)


### PR DESCRIPTION
…int without a space after the operator